### PR TITLE
Fixed usage of attributes as single string value

### DIFF
--- a/src/Kdyby/DoctrineCache/DI/Helpers.php
+++ b/src/Kdyby/DoctrineCache/DI/Helpers.php
@@ -108,7 +108,7 @@ class Helpers extends Nette\Object
 
 			} elseif ($v instanceof \stdClass && isset($v->value, $v->attributes)) {
 				$tmp = self::doFilterArguments(array($v->value));
-				$args[$k] = new Statement($tmp[0], self::doFilterArguments($v->attributes));
+				$args[$k] = new Statement($tmp[0], self::doFilterArguments(is_array($v->attributes) ? $v->attributes : array($v->attributes)));
 			}
 		}
 

--- a/tests/KdybyTests/DoctrineCache/Helpers.phpt
+++ b/tests/KdybyTests/DoctrineCache/Helpers.phpt
@@ -77,6 +77,12 @@ class HelpersTest extends Tester\TestCase
 				array(new Nette\DI\Statement('SplFileInfo', array(__FILE__, new Nette\DI\Statement('SplFileInfo', array(1 => __FILE__))))),
 				new Nette\DI\Statement('SplFileInfo', array(__FILE__, new Nette\DI\Statement('SplFileInfo', array('...', __FILE__))))
 			),
+
+			// single attribute does not have to be an array
+			array(
+				array(new Nette\DI\Statement('SplFileInfo', array(__FILE__))),
+				(object) array('value' => 'SplFileInfo', 'attributes' => __FILE__)
+			),
 		);
 	}
 


### PR DESCRIPTION
I have met an error that wrong parameter is given to `doFilterArguments` method. I am not sure if it is BC break however it does not work with some other packages at allowed versions.
