### PR TITLE
Fix $lifeTime condition in Cache::doSave

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -108,7 +108,7 @@ class Cache extends \Doctrine\Common\Cache\CacheProvider
 	protected function doSaveDependingOnFiles($id, $data, array $files, $lifeTime = 0)
 	{
 		$dp = [NCache::TAGS => ['doctrine'], NCache::FILES => $files];
-		if ($lifeTime !== 0) {
+		if ($lifeTime > 0) {
 			$dp[NCache::EXPIRE] = time() + $lifeTime;
 		}
 

--- a/tests/KdybyTests/DoctrineCache/CacheTest.phpt
+++ b/tests/KdybyTests/DoctrineCache/CacheTest.phpt
@@ -42,6 +42,18 @@ class CacheTest extends \Tester\TestCase
 		Assert::false($cache->fetch('nonexistent-key'));
 	}
 
+	public function testZeroAndNullLifetime()
+	{
+		$storage = new MemoryStorage();
+		$cache = new NetteCacheAdapter($storage, 'ns');
+
+		$cache->save('foo1', 'data', 0);
+		$cache->save('foo2', 'data', NULL);
+
+		Assert::true($cache->contains('foo1'));
+		Assert::true($cache->contains('foo2'));
+	}
+
 }
 
 (new CacheTest())->run();


### PR DESCRIPTION
`$lifeTime=NULL` probably should has same behaviour as `$lifeTime=0` in Cache::doSave. This change match condition with official Filesystem cache:
https://github.com/doctrine/cache/blob/v1.7.1/lib/Doctrine/Common/Cache/FilesystemCache.php#L102

Otherwise caching of ClassMetadata is broken and data is never cached. ClassMetadataFactory use `$lifeTime=NULL` with meaning `expire=never`:
https://github.com/doctrine/common/blob/v2.8.1/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php#L221