### PR TITLE
Nette 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"doctrine/cache": "^1.5",
 		"nette/di": "^3.0",
 		"nette/caching": "^3.0",
-		"kdyby/strict-objects": "^1.0"
+		"kdyby/strict-objects": "^2.0"
 	},
 	"require-dev": {
 		"doctrine/orm": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
 	},
 	"require": {
 		"php": "^7.1",
-		"doctrine/cache": "^1.5",
+		"doctrine/cache": "^1.8.0",
 		"nette/di": "^3.0",
 		"nette/caching": "^3.0",
 		"kdyby/strict-objects": "^2.0"
 	},
 	"require-dev": {
-		"doctrine/orm": "^2.5",
+		"doctrine/orm": "^2.6.3",
 		"symfony/validator": "^2.5.3 || ^3.0 || ^4.0",
 		"nette/bootstrap": "~2.4 || ^3.0",
 		"nette/tester": "2.2.*",

--- a/src/MemcacheCache.php
+++ b/src/MemcacheCache.php
@@ -14,6 +14,9 @@ namespace Kdyby\DoctrineCache;
 
 use Memcache;
 
+/**
+ * @deprecated
+ */
 class MemcacheCache extends \Doctrine\Common\Cache\MemcacheCache
 {
 

--- a/tests/KdybyTests/DoctrineCache/HelpersTest.phpt
+++ b/tests/KdybyTests/DoctrineCache/HelpersTest.phpt
@@ -11,7 +11,7 @@ declare(strict_types = 1);
 namespace KdybyTests\DoctrineCache;
 
 use Kdyby\DoctrineCache\DI\Helpers as DICacheHelpers;
-use Nette\DI\Statement;
+use Nette\DI\Definitions\Statement;
 use SplFileInfo;
 use Tester\Assert;
 


### PR DESCRIPTION
Update to current versions of packages.
Necessary prerequisite for Nette v3.0 version of Kdyby/Doctrine.